### PR TITLE
#68 feat: Tag 컴포넌트 생성

### DIFF
--- a/src/components/common/Tag/index.tsx
+++ b/src/components/common/Tag/index.tsx
@@ -3,6 +3,7 @@ import { HTMLAttributes } from 'react';
 import cn from '@utils/cn';
 
 type TagSizeType = 'small' | 'large';
+
 interface TagProps extends HTMLAttributes<HTMLDivElement> {
   size: TagSizeType;
 }
@@ -12,7 +13,12 @@ const tagStyleAttributes = {
   large: 'h-[32px] px-[12px] caption-12-bold',
 };
 
-export default function Tag({ children, className, size }: TagProps) {
+export default function Tag({
+  children,
+  className,
+  size,
+  ...restProps
+}: TagProps) {
   const tagStyles = tagStyleAttributes[size];
 
   return (
@@ -21,6 +27,7 @@ export default function Tag({ children, className, size }: TagProps) {
         `inline-flex justify-items items-center justify-between gap-[4px] rounded-[32px] py-[4px] ${tagStyles}`,
         className,
       )}
+      {...restProps}
     >
       {children}
     </div>

--- a/src/components/common/Tag/index.tsx
+++ b/src/components/common/Tag/index.tsx
@@ -2,19 +2,47 @@ import { ComponentProps, ReactNode } from 'react';
 
 import cn from '@utils/cn';
 
+type TagSizeType = 'small' | 'large';
 interface TagProps extends ComponentProps<'div'> {
-  leftItem?: ReactNode;
+  children: ReactNode;
+  size: TagSizeType;
+}
+interface TagStylesAttributes {
+  height: string;
+  width: string;
+  px: string;
+  textFont: string;
 }
 
-export default function Tag({ children, className, leftItem }: TagProps) {
+const getTagAttributes = (type: TagSizeType): TagStylesAttributes => {
+  switch (type) {
+    case 'small':
+      return {
+        height: 'h-[24px]',
+        width: 'w-[43px]',
+        px: 'px-[8px]',
+        textFont: 'caption-10-bold',
+      };
+    case 'large':
+      return {
+        height: 'h-[32px]',
+        width: 'w-[53px]',
+        px: 'px-[12px]',
+        textFont: 'caption-12-bold',
+      };
+  }
+};
+
+export default function Tag({ children, className, size }: TagProps) {
+  const { height, width, px, textFont } = getTagAttributes(size);
+  console.log(height, width, px, textFont);
   return (
     <div
       className={cn(
-        'flex justify-items items-center justify-between gap-[4px] h-[32px] w-[53px] rounded-[32px] px-[12px] py-[4px] caption-12-bold text-white bg-primary-300',
+        `flex justify-items items-center justify-between gap-[4px] rounded-[32px] py-[4px] ${px} ${height} ${width} ${textFont}`,
         className,
       )}
     >
-      {leftItem}
       {children}
     </div>
   );

--- a/src/components/common/Tag/index.tsx
+++ b/src/components/common/Tag/index.tsx
@@ -8,16 +8,14 @@ interface TagProps extends ComponentProps<'div'> {
 
 export default function Tag({ children, className, leftItem }: TagProps) {
   return (
-    <div className="flex">
-      <div
-        className={cn(
-          'flex justify-items items-center justify-between gap-[4px] h-[32px] rounded-[32px] px-[12px] py-[4px] caption-12-bold text-white bg-primary-300',
-          className,
-        )}
-      >
-        {leftItem}
-        {children}
-      </div>
+    <div
+      className={cn(
+        'flex justify-items items-center justify-between gap-[4px] h-[32px] w-[53px] rounded-[32px] px-[12px] py-[4px] caption-12-bold text-white bg-primary-300',
+        className,
+      )}
+    >
+      {leftItem}
+      {children}
     </div>
   );
 }

--- a/src/components/common/Tag/index.tsx
+++ b/src/components/common/Tag/index.tsx
@@ -1,0 +1,23 @@
+import { ComponentProps, ReactNode } from 'react';
+
+import cn from '@utils/cn';
+
+interface TagProps extends ComponentProps<'div'> {
+  leftItem?: ReactNode;
+}
+
+export default function Tag({ children, className, leftItem }: TagProps) {
+  return (
+    <div className="flex">
+      <div
+        className={cn(
+          'flex justify-items items-center justify-between gap-[4px] h-[32px] rounded-[32px] px-[12px] py-[4px] caption-12-bold text-white bg-primary-300',
+          className,
+        )}
+      >
+        {leftItem}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/Tag/index.tsx
+++ b/src/components/common/Tag/index.tsx
@@ -1,45 +1,24 @@
-import { ComponentProps, ReactNode } from 'react';
+import { HTMLAttributes } from 'react';
 
 import cn from '@utils/cn';
 
 type TagSizeType = 'small' | 'large';
-interface TagProps extends ComponentProps<'div'> {
-  children: ReactNode;
+interface TagProps extends HTMLAttributes<HTMLDivElement> {
   size: TagSizeType;
 }
-interface TagStylesAttributes {
-  height: string;
-  width: string;
-  px: string;
-  textFont: string;
-}
 
-const getTagAttributes = (type: TagSizeType): TagStylesAttributes => {
-  switch (type) {
-    case 'small':
-      return {
-        height: 'h-[24px]',
-        width: 'w-[43px]',
-        px: 'px-[8px]',
-        textFont: 'caption-10-bold',
-      };
-    case 'large':
-      return {
-        height: 'h-[32px]',
-        width: 'w-[53px]',
-        px: 'px-[12px]',
-        textFont: 'caption-12-bold',
-      };
-  }
+const tagStyleAttributes = {
+  small: 'h-[24px] w-[43px] px-[8px] caption-10-bold',
+  large: 'h-[32px] px-[12px] caption-12-bold',
 };
 
 export default function Tag({ children, className, size }: TagProps) {
-  const { height, width, px, textFont } = getTagAttributes(size);
-  console.log(height, width, px, textFont);
+  const tagStyles = tagStyleAttributes[size];
+
   return (
     <div
       className={cn(
-        `flex justify-items items-center justify-between gap-[4px] rounded-[32px] py-[4px] ${px} ${height} ${width} ${textFont}`,
+        `inline-flex justify-items items-center justify-between gap-[4px] rounded-[32px] py-[4px] ${tagStyles}`,
         className,
       )}
     >


### PR DESCRIPTION
## PR의 목적을 알려주세요.

close #68 

### Tag 컴포넌트 생성

## 어떤 변경사항이 있는지 알려주세요.

- `Tag` 컴포넌트를 생성했습니다. props로 `leftItem` 을 넣을 수 있게 해서 아이콘도 추가될 수 있게 했어요!
![image](https://github.com/depromeet/ddoeat_client/assets/110076475/b0c97427-4998-4512-b0b2-99190bcdc4e5)
- 그림에서 아래 두 회색 태그들은 단순 태그가 아니라 버튼이여서..! CTAButton 활용하면 되지 않을까 싶습니다!

## 중점적으로 봐주었으면 하는 부분
