### PR TITLE
#85 style: small tag width style 조정

### DIFF
--- a/src/components/common/Tag/index.tsx
+++ b/src/components/common/Tag/index.tsx
@@ -9,7 +9,7 @@ interface TagProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 const tagStyleAttributes = {
-  small: 'h-[24px] w-[43px] px-[8px] caption-10-bold',
+  small: 'h-[24px] px-[8px] caption-10-bold',
   large: 'h-[32px] px-[12px] caption-12-bold',
 };
 


### PR DESCRIPTION
## PR의 목적을 알려주세요.
Tag 중 small인 애의 태그 스타일 수정할 게 쪼금 생겨 간단하게 수정했습니다!

## 어떤 변경사항이 있는지 알려주세요.

타입이 small인 태그 width를 없애 width가 children값에 따라 유동적으로 변하게 수정하였습니다.

```ts
const tagStyleAttributes = {
  small: 'h-[24px] px-[8px] caption-10-bold', //width 삭제
  large: 'h-[32px] px-[12px] caption-12-bold',
};
```

## 중점적으로 봐주었으면 하는 부분
