### PR TITLE
#111 중심좌표 변경 throttle ms 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,7 +40,7 @@ export default function Home() {
     setCenter(newCenter);
   };
 
-  const throttledCenterChanged = useThrottle(handleCenterChanged, 10000);
+  const throttledCenterChanged = useThrottle(handleCenterChanged, 1000);
 
   return (
     <main className="flex h-[100dvh] max-h-[100dvh] flex-col items-center overflow-hidden">

--- a/src/components/main/CurrentLocationButton/index.tsx
+++ b/src/components/main/CurrentLocationButton/index.tsx
@@ -14,15 +14,15 @@ export default function CurrentLocationButton({
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    const handleWindowClick = (event: MouseEvent) => {
+    const handleOutsidePoint = (event: PointerEvent) => {
       if (!buttonRef.current?.contains(event.target as Node)) {
         setIsActive(false);
       }
     };
 
-    window.addEventListener('click', handleWindowClick);
+    window.addEventListener('pointerdown', handleOutsidePoint);
 
-    return () => window.removeEventListener('click', handleWindowClick);
+    return () => window.removeEventListener('pointerdown', handleOutsidePoint);
   }, []);
 
   const handleClick = (e: React.PointerEvent<HTMLButtonElement>) => {

--- a/src/hooks/useCoordinate.ts
+++ b/src/hooks/useCoordinate.ts
@@ -54,8 +54,9 @@ const useCoordinate = () => {
     center,
     setCenter,
     currentUserCoordinate,
-    getCurrentUserCoordinate: () =>
-      getCurrentUserCoordinate(onSuccess(), onError),
+    getCurrentUserCoordinate: (
+      addtionalCallback: (pos: GeolocationPosition) => void,
+    ) => getCurrentUserCoordinate(onSuccess(addtionalCallback), onError),
     getCurrentUserCoordinateInterval,
   };
 };


### PR DESCRIPTION
## PR의 목적을 알려주세요.

close #111 

## 어떤 변경사항이 있는지 알려주세요.

중심좌표 변경하는 쓰로틀 로직의 ms를 1초로 변경했습니다.
10초로 했는데 이러면 10초동안 제 위치로 이동하는게 막히더군요... 현위치와 현중심좌표가 동일해서 이동을 하지 않나봅니다.
이제 지도 이동시점으로 1초가 지나면 제 위치로 찾아가는 기능이 정상 동작합니다. 1초면 충분할듯

추가로 CurrentLocationButton의 이벤트가 click으로 되어있어 pointerdown으로 변경합니다~

## 중점적으로 봐주었으면 하는 부분
