### PR TITLE
검색 페이지 로직 수정

### DIFF
--- a/src/api/api-config.ts
+++ b/src/api/api-config.ts
@@ -33,6 +33,9 @@ axiosInstance.interceptors.request.use(
       delete config.headers['Authorization'];
     }
 
+    config.headers['Authorization'] =
+      'Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsInVzZXJJZCI6NiwiZXhwIjoxNzA3NDA2ODgzfQ.gCKKwQUUOaZ_orSuQ3qo9HEhr0ZalFXUpyOfwUAYRJEHrnNvmoAEcjR-68WCU3P1WgeKNKq18LXFKN1afmwhuQ';
+
     return config;
   },
   function (error) {

--- a/src/api/api-config.ts
+++ b/src/api/api-config.ts
@@ -33,9 +33,6 @@ axiosInstance.interceptors.request.use(
       delete config.headers['Authorization'];
     }
 
-    config.headers['Authorization'] =
-      'Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsInVzZXJJZCI6NiwiZXhwIjoxNzA3NDA2ODgzfQ.gCKKwQUUOaZ_orSuQ3qo9HEhr0ZalFXUpyOfwUAYRJEHrnNvmoAEcjR-68WCU3P1WgeKNKq18LXFKN1afmwhuQ';
-
     return config;
   },
   function (error) {

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -18,6 +18,10 @@ import useStorageState from '@utils/useStorageState';
 import useIsMounted from '@hooks/useIsMounted';
 
 export default function Page() {
+  const type = useSearchParams().get('type');
+  const latitude = useSearchParams().get('latitude') as string;
+  const longitude = useSearchParams().get('longitude') as string;
+
   const isMounted = useIsMounted();
   const [text, onTextChange, setValue, resetText] = useInput('');
   const debouncedText = useDebounce(text, 500);
@@ -26,20 +30,16 @@ export default function Page() {
     string[]
   >({ key: 'recentSearchKeywords', initialValue: [] });
 
-  const queries = useSearchParams().values();
-
   // TODO: 추후 위, 경도 추가
   const { data, refetch } = useGetStoreList({
     keyword: debouncedText,
-    longitude: '127.0628310',
-    latitude: '37.51432257',
+    longitude,
+    latitude,
   });
 
   const storeList = data?.storeSearchResult;
 
   const isStoreListNone = storeList?.length === 0;
-
-  const type = useSearchParams().get('type');
 
   const handleClickSearchButton = () => {
     setRecentSearchKeywords((prev) => {
@@ -105,9 +105,7 @@ export default function Page() {
             <NoSearchResult />
           ) : (
             storeList?.map((store, index) => {
-              // NOTE: 위, 경도는 추후 페이지 간 넘겨주는 데이터에 사용될 예정
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              const { storeId, latitude, longitude, distance, ...rest } = store;
+              const { storeId, distance, ...rest } = store;
 
               return (
                 // TODO: 클릭 시 이동 url 확정되면 수정

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -27,7 +27,6 @@ export default function Page() {
   >({ key: 'recentSearchKeywords', initialValue: [] });
 
   const queries = useSearchParams().values();
-  console.log(queries);
 
   // TODO: 추후 위, 경도 추가
   const { data, refetch } = useGetStoreList({

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -26,6 +26,9 @@ export default function Page() {
     string[]
   >({ key: 'recentSearchKeywords', initialValue: [] });
 
+  const queries = useSearchParams().values();
+  console.log(queries);
+
   // TODO: 추후 위, 경도 추가
   const { data, refetch } = useGetStoreList({
     keyword: debouncedText,
@@ -111,10 +114,9 @@ export default function Page() {
                 // TODO: 클릭 시 이동 url 확정되면 수정
                 <Link
                   href={{
-                    pathname: `/?storeId=${storeId}`,
-                    query: { ...store },
+                    pathname: '/',
+                    query: { type: 'search', ...store },
                   }}
-                  as={`/?storeId=${storeId}`}
                   key={storeId}
                 >
                   <SearchItem

--- a/src/components/search/SearchItem/index.tsx
+++ b/src/components/search/SearchItem/index.tsx
@@ -4,8 +4,8 @@ import Tag from '@components/common/Tag';
 
 interface SearchItemProps extends Omit<BasicListItem, 'hasDeleteOption'> {
   storeName: string;
-  categoryName: string;
-  revisitedCount: number;
+  categoryType: string;
+  totalRevisitedCount: number;
   distance: string;
   address: string;
 }
@@ -13,8 +13,8 @@ interface SearchItemProps extends Omit<BasicListItem, 'hasDeleteOption'> {
 export default function SearchItem({
   isLast,
   storeName,
-  categoryName,
-  revisitedCount,
+  categoryType,
+  totalRevisitedCount,
   distance,
   address,
 }: SearchItemProps) {
@@ -22,10 +22,10 @@ export default function SearchItem({
     <ListItem isLast={isLast} hasDeleteOption={false}>
       <div className="flex items-center gap-[4px]">
         <p className="body-16-bold">{storeName}</p>
-        <p className="caption-12-bold text-gray-500">{categoryName}</p>
-        {revisitedCount > 0 && (
+        <p className="caption-12-bold text-gray-500">{categoryType}</p>
+        {totalRevisitedCount > 0 && (
           <Tag size={'small'} className="bg-primary-100 text-primary-500">
-            {revisitedCount}명 재방문
+            {totalRevisitedCount}명 재방문
           </Tag>
         )}
       </div>

--- a/src/hooks/api/useGetStoreList.ts
+++ b/src/hooks/api/useGetStoreList.ts
@@ -13,6 +13,7 @@ interface StoreSearch {
   address: string;
   categoryType: string;
   distance: number;
+  kakaoCategoryName: string;
   kakaoStoreId: number;
   latitude: number;
   longitude: number;

--- a/src/hooks/api/useGetStoreList.ts
+++ b/src/hooks/api/useGetStoreList.ts
@@ -10,14 +10,15 @@ interface StoreListQueries {
 }
 
 interface StoreSearch {
-  storeId: number;
-  storeName: string;
-  categoryName: string;
   address: string;
+  categoryType: string;
   distance: number;
-  revisitedCount: number;
+  kakaoStoreId: number;
   latitude: number;
   longitude: number;
+  storeId: number | null;
+  storeName: string;
+  totalRevisitedCount: number;
 }
 
 interface StoreListResponse {


### PR DESCRIPTION
## PR의 목적을 알려주세요.
close #126 
## 어떤 변경사항이 있는지 알려주세요.
1. `kakaoStoreId` 추가하였습니다.
2. 검색페이지에서 지도 페이지로 이동할 때 `?type=search` 붙여서 보내도록 하였습니다.
3. 지도페이지에서 받은 위, 경도로 검색 요청하도록 수정하였습니다.
## 중점적으로 봐주었으면 하는 부분
