### PR TITLE
fix: ReactNativeWebview 일때만 postMessage 보내도록 수정

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -11,7 +11,9 @@ interface TokenRefreshResponse {
 export const removeTokenAndMoveToLogin = () => {
   Cookies.remove('accessToken');
   Cookies.remove('refreshToken');
-  window.ReactNativeWebView.postMessage(TOKEN_NULL_MESSAGE);
+  if (window?.ReactNativeWebView) {
+    window.ReactNativeWebView.postMessage(TOKEN_NULL_MESSAGE);
+  }
   window.location.href = '/login';
 };
 


### PR DESCRIPTION
## PR의 목적을 알려주세요.

close #217 

## 어떤 변경사항이 있는지 알려주세요.

그냥 웹에서 실행했을 때 아래 에러가 납니다..! ReactNativeWebview 존재할 때만 앱으로 메시지 보내도록 수정했습니다. 
![image](https://github.com/depromeet/ddoeat_client/assets/110076475/31e7e7b2-391f-4a61-a82c-2356ceda5108)


## 중점적으로 봐주었으면 하는 부분
