### PR TITLE
fix : 또잇 리포트 넓이 수정

### DIFF
--- a/src/components/main/StoreDetailSection/Report/ReportContainer.tsx
+++ b/src/components/main/StoreDetailSection/Report/ReportContainer.tsx
@@ -9,7 +9,7 @@ export default function ReportContainer({
   return (
     <div
       className={cn(
-        'w-[168px] h-[130px] bg-primary-300 rounded-[24px] text-white flex flex-col justify-end items-center ',
+        'w-1/2 h-[130px] bg-primary-300 rounded-[24px] text-white flex flex-col justify-end items-center ',
         className,
       )}
     >

--- a/src/components/main/StoreDetailSection/Report/ReportContainer.tsx
+++ b/src/components/main/StoreDetailSection/Report/ReportContainer.tsx
@@ -9,7 +9,7 @@ export default function ReportContainer({
   return (
     <div
       className={cn(
-        'w-1/2 h-[130px] bg-primary-300 rounded-[24px] text-white flex flex-col justify-end items-center ',
+        'w-1/2 min-w-fit h-[130px] bg-primary-300 rounded-[24px] text-white flex flex-col justify-end items-center ',
         className,
       )}
     >

--- a/src/components/main/StoreDetailSection/Report/index.tsx
+++ b/src/components/main/StoreDetailSection/Report/index.tsx
@@ -4,9 +4,9 @@ import TopVisit from './TopVisit';
 
 export default function Report() {
   return (
-    <div className="px-[16px]  pb-[8px]">
+    <div className="px-[16px] pb-[8px]">
       <SectionTitle>또잇또잇 리포트</SectionTitle>
-      <div className="flex gap-[8px] mx-[16px] my-[4px]  justify-center items-center">
+      <div className="flex gap-[8px] justify-center items-center">
         <TopVisit />
         <ReVisit />
       </div>


### PR DESCRIPTION
## PR의 목적을 알려주세요.
close #222 

## 어떤 변경사항이 있는지 알려주세요.
기존에는 피그마에서 정해진 width값으로 리포트 넓이를 줬는데 위랑 안맞는 오류가 있어서
![image](https://github.com/depromeet/ddoeat_client/assets/27201591/19dedc7f-a815-4f09-9e63-95ebdc07ce90)
위에 또잇또잇 리포트랑 맞추고, 디바이스 크기에 맞게 늘어나게 해달라고 하셔서 변경했습니다.
<img width="373" alt="image" src="https://github.com/depromeet/ddoeat_client/assets/27201591/3f7d6724-4032-4c69-b8e1-f5953e89e825">

+ 비율도 맞게 줄어들게 예시를 주셔서 `min-w-fit`으로 해놨습니당
<img width="308" alt="image" src="https://github.com/depromeet/ddoeat_client/assets/27201591/bfe413a7-fe32-4ec8-b22e-47bb8c8abfe9">



## 중점적으로 봐주었으면 하는 부분
